### PR TITLE
Draft for polling interval configuration flow

### DIFF
--- a/homeassistant/components/landisgyr_heat_meter/__init__.py
+++ b/homeassistant/components/landisgyr_heat_meter/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_DEVICE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .const import DOMAIN, POLLING_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name="ultraheat_gateway",
         update_method=async_update_data,
-        update_interval=timedelta(days=1),
+        update_interval=timedelta(hours=entry.data[POLLING_INTERVAL]),
     )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator

--- a/homeassistant/components/landisgyr_heat_meter/const.py
+++ b/homeassistant/components/landisgyr_heat_meter/const.py
@@ -9,6 +9,7 @@ from homeassistant.const import ENERGY_MEGA_WATT_HOUR, TEMP_CELSIUS, VOLUME_CUBI
 from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "landisgyr_heat_meter"
+POLLING_INTERVAL = "polling_interval"
 
 GJ_TO_MWH = 0.277778  # conversion factor
 ULTRAHEAT_TIMEOUT = 30  # reading the IR port can take some time

--- a/homeassistant/components/landisgyr_heat_meter/strings.json
+++ b/homeassistant/components/landisgyr_heat_meter/strings.json
@@ -3,12 +3,14 @@
     "step": {
       "user": {
         "data": {
-          "device": "Select device"
+          "device": "Select device",
+          "polling_interval": "Polling interval (default = 24h)"
         }
       },
       "setup_serial_manual_path": {
         "data": {
-          "device": "[%key:common::config_flow::data::usb_path%]"
+          "device": "[%key:common::config_flow::data::usb_path%]",
+          "polling_interval": "Polling interval (default = 24h)"
         }
       }
     },

--- a/homeassistant/components/landisgyr_heat_meter/translations/sv.json
+++ b/homeassistant/components/landisgyr_heat_meter/translations/sv.json
@@ -10,12 +10,14 @@
         "step": {
             "setup_serial_manual_path": {
                 "data": {
-                    "device": "USB-enhetens s\u00f6kv\u00e4g"
+                    "device": "USB-enhetens s\u00f6kv\u00e4g",
+                    "polling_interval": "Uppdateringsfrekvens (default=24h)"
                 }
             },
             "user": {
                 "data": {
-                    "device": "V\u00e4lj enhet"
+                    "device": "V\u00e4lj enhet",
+                    "polling_interval": "Uppdateringsfrekvens (default=24h)"
                 }
             }
         }


### PR DESCRIPTION
Allows the user to set a custom polling interval (defaults to 24 h to not break anything). Hours were chosen as that is the smallest unit that the UH50 and T550 seems to aggregate against. My T550 does run on mains, with battery as backup - so I would prefer if there was an option for polling this much more often.

I have not yet set up a local dev env for HA, so this is very much a draft. Have tested it as a copied custom component. It seems to miss out on the headers ("Landis+Gyr Heat Meter",  "Select device", "Polling interval (default = 24h)"). I have no idea why.

This is more targeted as a PoC. Perhaps you have the time to make it great, if not, I will try to set up the dev env when time allows :)